### PR TITLE
Added md5 integration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,6 +106,7 @@ resource "equinix_metal_virtual_circuit" "my_vc_pri" {
     subnet        = var.bgp_peer_subnet_pri
     metal_ip      = var.metal_bgp_ip_pri
     customer_ip   = var.customer_bgp_ip_pri
+    md5           = var.bgp_md5_pri
 } 
 
 resource "equinix_metal_virtual_circuit" "my_vc_sec" {
@@ -120,5 +121,6 @@ resource "equinix_metal_virtual_circuit" "my_vc_sec" {
     subnet        = var.bgp_peer_subnet_sec
     metal_ip      = var.metal_bgp_ip_sec
     customer_ip   = var.customer_bgp_ip_sec
+    md5           = var.bgp_md5_sec
 }
 

--- a/modules/metalnodes/main.tf
+++ b/modules/metalnodes/main.tf
@@ -68,6 +68,6 @@ resource "equinix_metal_port" "port" {
   layer2   = true
   bonded   = true
   vlan_ids = var.metal_vlan.*.id
-  depends_on = [equinix_metal_device.metal_nodes, equinix_metal_device.metal_nodes]
+  depends_on = [equinix_metal_device.metal_nodes]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -108,3 +108,15 @@ variable "ip_ranges" {
   type        = list(any)
   description = "Your reserved IP ranges"
 }
+
+variable "bgp_md5_pri" {
+  type = string
+  description = "BGP password of primary connection"
+  default = null
+}
+
+variable "bgp_md5_sec" {
+  type = string
+  description = "BGP password of secondary connection"
+  default = null
+}


### PR DESCRIPTION
Integrating BGP with major cloud providers, such as AWS, requires providing password (which cannot be null). Therefore, added the md5 variable to both primary and secondary virtual circuit resources.