### PR TITLE
Add provider meta module_name in Equinix Metal TF configs

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/equinix/equinix" {
   version     = "1.14.1"
-  constraints = "1.14.1"
+  constraints = "~> 1.14"
   hashes = [
+    "h1:RPOKuf08oOp6TVstX6LZvme7CDaXGizlCGGqmmclmwI=",
     "h1:leVuWUGydv+Nbs7Mmjm4iOF/mu+GWploPZW9dg7r3IY=",
     "zh:1b478c206ae88a3bfd4ab376ce19e5c577b8f3389005cc159bb041b6dc9e00b1",
     "zh:24b793281076cd57ac42665d919406ba4077768db01b0f1f1e7daff814159a49",

--- a/example.tfvars
+++ b/example.tfvars
@@ -3,13 +3,13 @@
 ## 2. nni_vlan need to be the same as you specified in your VC setup via Fabric Portal
 ## 3. in the following example, 169.254.100.0/24 is the BGP IPs (or BGP neighbors' IP), 192.168.100.0/24 is the network IP prefix you plan to advertise via BGP sessions
 
-auth_token         = "your_metal_api_token"
-project_id         = "your_metal_project_id"
-metro              = "ny"
-plan               = "c3.small.x86"
-operating_system   = "ubuntu_20_04"
-server_count       = 2
-vlan_count         = 2
-nni_vlan           = 999
-dedicated_port_id  = "your_metal_dedicated_port_UUID"
-ip_ranges          = ["169.254.100.0/24", "192.168.100.0/24"]
+auth_token        = "your_metal_api_token"
+project_id        = "your_metal_project_id"
+metro             = "ny"
+plan              = "c3.small.x86"
+operating_system  = "ubuntu_20_04"
+server_count      = 2
+vlan_count        = 2
+nni_vlan          = 999
+dedicated_port_id = "your_metal_dedicated_port_UUID"
+ip_ranges         = ["169.254.100.0/24", "192.168.100.0/24"]

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,14 @@
 # define provider version and Metal Token
 terraform {
+  required_version = ">= 1.0.0"
   required_providers {
     equinix = {
-      source = "equinix/equinix"
-      version = "1.14.1"
+      source  = "equinix/equinix"
+      version = "~> 1.14"
     }
+  }
+  provider_meta "equinix" {
+    module_name = "equinix-metal-vrf"
   }
 }
 
@@ -30,7 +34,7 @@ module "ssh" {
 
 # deploy Metal server(s)
 
-module "metal_nodes" {
+module "equinix_metal_nodes" {
   source           = "./modules/metalnodes/"
   project_id       = var.project_id
   node_count       = var.server_count
@@ -39,7 +43,7 @@ module "metal_nodes" {
   operating_system = var.operating_system
   metal_vlan       = [for v in equinix_metal_vlan.metro_vlan[*] : { vxlan = v.vxlan, id = v.id }]
   ssh_key          = module.ssh.ssh_private_key_contents
-  depends_on       = [equinix_metal_vlan.metro_vlan, module.ssh] 
+  depends_on       = [equinix_metal_vlan.metro_vlan, module.ssh]
 }
 
 
@@ -50,12 +54,12 @@ module "metal_nodes" {
 # "192.168.200.0/24" will be assigned to gateway-2 and its associated metal nodes.
 
 resource "equinix_metal_vrf" "my_vrf" {
-   description = "VRF with ASN 65100 and a pool of address space that includes a subnet for your BGP and subnets for each of your Metal Gateways"
-   name        = "my-vrf"
-   metro       = var.metro
-   project_id  = var.project_id
-   local_asn   = var.metal_asn
-   ip_ranges   = var.ip_ranges
+  description = "VRF with ASN 65100 and a pool of address space that includes a subnet for your BGP and subnets for each of your Metal Gateways"
+  name        = "my-vrf"
+  metro       = var.metro
+  project_id  = var.project_id
+  local_asn   = var.metal_asn
+  ip_ranges   = var.ip_ranges
 }
 
 # Create an IP reservation from the reserved IP pools (varibale ip_ranges) and assign them to a Metal Gateway resources. 
@@ -64,29 +68,29 @@ resource "equinix_metal_vrf" "my_vrf" {
 # Note, you'll need at least one gateway for each subnet you reserved in resource "equinix_metal_vrf" 
 
 resource "equinix_metal_reserved_ip_block" "my_gateway_ip" {
-    description = "Reserved gateway IP block (192.168.100.0/24) taken from one of the ranges in the VRF's pool of address space ip_ranges. "
-    project_id  = var.project_id
-    metro       = var.metro
-    type        = "vrf"
-    vrf_id      = equinix_metal_vrf.my_vrf.id
-    cidr        = 29
-    network     = "192.168.100.0"
+  description = "Reserved gateway IP block (192.168.100.0/24) taken from one of the ranges in the VRF's pool of address space ip_ranges. "
+  project_id  = var.project_id
+  metro       = var.metro
+  type        = "vrf"
+  vrf_id      = equinix_metal_vrf.my_vrf.id
+  cidr        = 29
+  network     = "192.168.100.0"
 }
 
 # Create a gateway in my current project and assign the reserved IP and the metal's metro vlan to the gateway
 # please notice "vlan_id" is the Metro VLAN's UUID
 
 resource "equinix_metal_gateway" "my_gateway" {
-    project_id        = var.project_id
-    vlan_id           = equinix_metal_vlan.metro_vlan[0].id
-    ip_reservation_id = equinix_metal_reserved_ip_block.my_gateway_ip.id
+  project_id        = var.project_id
+  vlan_id           = equinix_metal_vlan.metro_vlan[0].id
+  ip_reservation_id = equinix_metal_reserved_ip_block.my_gateway_ip.id
 }
 
 
 # The "dedicated_port_id" is the UUID of your dedicated port obtained in Metal's Portal
 
 data "equinix_metal_connection" "dedicated_port" {
-    connection_id = var.dedicated_port_id
+  connection_id = var.dedicated_port_id
 }
 
 # Create a VC (Virtual Connection) or a pair of VCs for HA (Primary and Secondary respectively) connecting VRF with the far-end (customer end). "metal_ip" is the BGP Speaker IP address of the VRF which will default to the first usable IP in the subnet. It peers with the "customer_ip".
@@ -95,32 +99,32 @@ data "equinix_metal_connection" "dedicated_port" {
 # This resource will ONLY create the connection on the Metal's portal. You'll need to setup the VC in fabric portal using the same "nni_vlan" first
 
 resource "equinix_metal_virtual_circuit" "my_vc_pri" {
-    name          = "virtual_connection_pri"
-    description   = "Primary Virtual Circuit"
-    connection_id = data.equinix_metal_connection.dedicated_port.id
-    project_id    = var.project_id
-    port_id       = data.equinix_metal_connection.dedicated_port.ports[0].id
-    nni_vlan      = var.nni_vlan
-    vrf_id        = equinix_metal_vrf.my_vrf.id
-    peer_asn      = var.customer_asn
-    subnet        = var.bgp_peer_subnet_pri
-    metal_ip      = var.metal_bgp_ip_pri
-    customer_ip   = var.customer_bgp_ip_pri
-    md5           = var.bgp_md5_pri
-} 
+  name          = "virtual_connection_pri"
+  description   = "Primary Virtual Circuit"
+  connection_id = data.equinix_metal_connection.dedicated_port.id
+  project_id    = var.project_id
+  port_id       = data.equinix_metal_connection.dedicated_port.ports[0].id
+  nni_vlan      = var.nni_vlan
+  vrf_id        = equinix_metal_vrf.my_vrf.id
+  peer_asn      = var.customer_asn
+  subnet        = var.bgp_peer_subnet_pri
+  metal_ip      = var.metal_bgp_ip_pri
+  customer_ip   = var.customer_bgp_ip_pri
+  md5           = var.bgp_md5_pri
+}
 
 resource "equinix_metal_virtual_circuit" "my_vc_sec" {
-    name          = "virtual_connection_sec"
-    description   = "Secondary Virtual Circuit"
-    connection_id = data.equinix_metal_connection.dedicated_port.id
-    project_id    = var.project_id
-    port_id       = data.equinix_metal_connection.dedicated_port.ports[1].id
-    vrf_id        = equinix_metal_vrf.my_vrf.id
-    nni_vlan      = var.nni_vlan
-    peer_asn      = var.customer_asn
-    subnet        = var.bgp_peer_subnet_sec
-    metal_ip      = var.metal_bgp_ip_sec
-    customer_ip   = var.customer_bgp_ip_sec
-    md5           = var.bgp_md5_sec
+  name          = "virtual_connection_sec"
+  description   = "Secondary Virtual Circuit"
+  connection_id = data.equinix_metal_connection.dedicated_port.id
+  project_id    = var.project_id
+  port_id       = data.equinix_metal_connection.dedicated_port.ports[1].id
+  vrf_id        = equinix_metal_vrf.my_vrf.id
+  nni_vlan      = var.nni_vlan
+  peer_asn      = var.customer_asn
+  subnet        = var.bgp_peer_subnet_sec
+  metal_ip      = var.metal_bgp_ip_sec
+  customer_ip   = var.customer_bgp_ip_sec
+  md5           = var.bgp_md5_sec
 }
 

--- a/modules/metalnodes/main.tf
+++ b/modules/metalnodes/main.tf
@@ -1,10 +1,15 @@
 
 # define provider version and Metal Token
 terraform {
+  required_version = ">= 1.0.0"
   required_providers {
     equinix = {
       source = "equinix/equinix"
+      version = "~> 1.14"
     }
+  }
+  provider_meta "equinix" {
+    module_name = "equinix-metal-vrf/metalnodes"
   }
 }
 

--- a/modules/ssh/main.tf
+++ b/modules/ssh/main.tf
@@ -2,7 +2,12 @@ terraform {
   required_providers {
     equinix = {
       source = "equinix/equinix"
+      version = "~> 1.14"
     }
+  }
+  required_version = ">= 1.0.0"
+  provider_meta "equinix" {
+    module_name = "equinix-metal-vrf/ssh"
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,13 +4,13 @@ output "metrovlan_ids" {
 }
 
 output "server_name" {
-  value       = module.metal_nodes.node_names
+  value       = module.equinix_metal_nodes.node_names
   description = "Your metal node's hostname:"
 }
 
 /* Don't output metal nodes' IPs in layer2 mode
 output "metal_node_ip" {
-  value       = module.metal_nodes.nodes_public_ipv4
+  value       = module.equinix_metal_nodes.nodes_public_ipv4
   description = "Your metal node's IP addresses:"
 }
 */
@@ -30,7 +30,7 @@ output "metal_gateway" {
   description = "The Gateway Information:"
 }
 output "dedicated_ports" {
-  value       = {
+  value = {
     port_id    = data.equinix_metal_connection.dedicated_port.id,
     name       = data.equinix_metal_connection.dedicated_port.name,
     metro      = data.equinix_metal_connection.dedicated_port.metro,
@@ -40,25 +40,25 @@ output "dedicated_ports" {
 }
 
 output "virtual_connection_primary" {
-  value       = {
-    vc_id     = equinix_metal_virtual_circuit.my_vc_pri.id,
-    name      = equinix_metal_virtual_circuit.my_vc_pri.name,
-    nni_vlan  = equinix_metal_virtual_circuit.my_vc_pri.nni_vlan,
-    peer_asn  = equinix_metal_virtual_circuit.my_vc_pri.peer_asn,
-    peer_ip   = equinix_metal_virtual_circuit.my_vc_pri.customer_ip,
-    metal_ip  = equinix_metal_virtual_circuit.my_vc_pri.metal_ip
+  value = {
+    vc_id    = equinix_metal_virtual_circuit.my_vc_pri.id,
+    name     = equinix_metal_virtual_circuit.my_vc_pri.name,
+    nni_vlan = equinix_metal_virtual_circuit.my_vc_pri.nni_vlan,
+    peer_asn = equinix_metal_virtual_circuit.my_vc_pri.peer_asn,
+    peer_ip  = equinix_metal_virtual_circuit.my_vc_pri.customer_ip,
+    metal_ip = equinix_metal_virtual_circuit.my_vc_pri.metal_ip
   }
   description = "Information of Primary VC connecting to VRF"
 }
 
 output "virtual_connection_secondary" {
-  value       = {
-    vc_id     = equinix_metal_virtual_circuit.my_vc_sec.id,
-    name      = equinix_metal_virtual_circuit.my_vc_sec.name,
-    nni_vlan  = equinix_metal_virtual_circuit.my_vc_sec.nni_vlan,
-    peer_asn  = equinix_metal_virtual_circuit.my_vc_sec.peer_asn,
-    peer_ip   = equinix_metal_virtual_circuit.my_vc_sec.customer_ip,
-    metal_ip  = equinix_metal_virtual_circuit.my_vc_sec.metal_ip
+  value = {
+    vc_id    = equinix_metal_virtual_circuit.my_vc_sec.id,
+    name     = equinix_metal_virtual_circuit.my_vc_sec.name,
+    nni_vlan = equinix_metal_virtual_circuit.my_vc_sec.nni_vlan,
+    peer_asn = equinix_metal_virtual_circuit.my_vc_sec.peer_asn,
+    peer_ip  = equinix_metal_virtual_circuit.my_vc_sec.customer_ip,
+    metal_ip = equinix_metal_virtual_circuit.my_vc_sec.metal_ip
   }
   description = "Information of Secondary VC connecting to VRF"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -110,13 +110,13 @@ variable "ip_ranges" {
 }
 
 variable "bgp_md5_pri" {
-  type = string
+  type        = string
   description = "BGP password of primary connection"
-  default = null
+  default     = null
 }
 
 variable "bgp_md5_sec" {
-  type = string
+  type        = string
   description = "BGP password of secondary connection"
-  default = null
+  default     = null
 }


### PR DESCRIPTION
What this PR does / why we need it:
It allows Vendor to declare the metadata fields. It adds provider meta module_name in Equinix Metal TF configs

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

Related to https://github.com/equinix/terraform-provider-equinix/issues/252